### PR TITLE
Use `editor.wordSeparators` in order to classify characters.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ enum CharClass {
     Hiragana,
     Katakana,
     Other,
+    Separator,
     Invalid
 }
 
@@ -140,6 +141,11 @@ function classifyChar(doc: vscode.TextDocument, position: vscode.Position) {
     if( text.length == 0 )
         return CharClass.Invalid;           // beyond an end-of-line / an end-of-document.
     const ch = text.charCodeAt(0);
+
+    const wordSeparators = vscode.workspace.getConfiguration().get('editor.wordSeparators') as String;
+    if (wordSeparators.indexOf(text) !== -1) {
+        return CharClass.Separator;
+    }
 
     if( (0x09 <= ch && ch <= 0x0d) || ch == 0x20 || ch == 0x3000 )
         return CharClass.Whitespace;


### PR DESCRIPTION
This change solves a problem that japanese-word-handler ignores `editor.wordSeparators` setting.

## About an issue

The current japanese-word-handler does not check `editor.wordSeparators` setting in classifyChar.
Thus, the separators (e.g., underscore) are ignored.

For example, when editor.wordSeparators contains underscore (_),
```
editor.wordSeparators: "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?_"
```

expected cursor move is:

```
‸classify_char
      ↓
classify‸_char
```

actual:

```
‸classify_char
      ↓
classify_char‸
```

## About this change

This commit adds new character class `Separator` and classify `editor.wordSeparators` into `Separator`.