### PR TITLE
fix: Do not activate inside non-editor window

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,24 +110,24 @@
             {
                 "command": "japaneseWordHandler.deleteWordEndLeft",
                 "key": "ctrl+alt+shift+9",
-                "when": "textInputFocus && !editorReadonly"
+                "when": "editorTextFocus && !editorReadonly"
             },
             {
                 "command": "japaneseWordHandler.deleteWordEndRight",
                 "key": "ctrl+delete",
                 "mac": "alt+delete",
-                "when": "textInputFocus && !editorReadonly"
+                "when": "editorTextFocus && !editorReadonly"
             },
             {
                 "command": "japaneseWordHandler.deleteWordStartLeft",
                 "key": "ctrl+backspace",
                 "mac": "alt+backspace",
-                "when": "textInputFocus && !editorReadonly"
+                "when": "editorTextFocus && !editorReadonly"
             },
             {
                 "command": "japaneseWordHandler.deleteWordStartRight",
                 "key": "ctrl+alt+shift+9",
-                "when": "textInputFocus && !editorReadonly"
+                "when": "editorTextFocus && !editorReadonly"
             }
         ]
     },


### PR DESCRIPTION
Previously some keybindings to delete a word were activated when *ANY*
text-editing window is focused. Because of the misconfiguration,
pressing those shortcut keys deletes a word in an active file editing
window even if it is not focused. For example, this misbehavior happens
when the user focuses on:

- Input box to enter Git commit log
- Input box to filter available extensions
- Input box to filter setting items

Closes #5