### PR TITLE
fix: Add "workspace" to remote.extensionKind (#11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "Other"
     ],
     "extensionKind": [
-        "ui"
+        "ui",
+        "workspace"
     ],
     "license": "Zlib",
     "badges": [


### PR DESCRIPTION
I mistakenly picked a non-compatible value `["ui"]` for
`remote.extensionKind` when I adopted package.json to modern VS Code
(1.40 or later):
2790ff846c6fafa4e88282051bde84ef23697ba0